### PR TITLE
Log start of tasks

### DIFF
--- a/tests/test_dramatiq_task_logger.py
+++ b/tests/test_dramatiq_task_logger.py
@@ -37,31 +37,34 @@ def message():
 
 @pytest.fixture
 def expected():
-    return [{
-        "id": 1,
-        "tag_suffix": "task_log",
-        "task_id": "abc123",
-        "name": "my_task",
-        "state": "STARTING",
-        "duration": 0,
-        "retries": 0,
-        "origin": f"host-{os.getpid()}",
-        "argsrepr": b"[1,2]",
-        "kwargsrepr": b'{"foo":"bar"}',
-        "result": None,
-    },{
-        "id": 1,
-        "tag_suffix": "task_log",
-        "task_id": "abc123",
-        "name": "my_task",
-        "state": "SUCCESS",
-        "duration": 0,
-        "retries": 0,
-        "origin": f"host-{os.getpid()}",
-        "argsrepr": b"[1,2]",
-        "kwargsrepr": b'{"foo":"bar"}',
-        "result": None,
-    }]
+    return [
+        {
+            "id": 1,
+            "tag_suffix": "task_log",
+            "task_id": "abc123",
+            "name": "my_task",
+            "state": "STARTING",
+            "duration": 0,
+            "retries": 0,
+            "origin": f"host-{os.getpid()}",
+            "argsrepr": b"[1,2]",
+            "kwargsrepr": b'{"foo":"bar"}',
+            "result": None,
+        },
+        {
+            "id": 2,
+            "tag_suffix": "task_log",
+            "task_id": "abc123",
+            "name": "my_task",
+            "state": "SUCCESS",
+            "duration": 0,
+            "retries": 0,
+            "origin": f"host-{os.getpid()}",
+            "argsrepr": b"[1,2]",
+            "kwargsrepr": b'{"foo":"bar"}',
+            "result": None,
+        },
+    ]
 
 
 @mock.patch("time.time", return_value=123)

--- a/tests/test_dramatiq_task_logger.py
+++ b/tests/test_dramatiq_task_logger.py
@@ -54,7 +54,7 @@ def expected():
 
 @mock.patch("time.time", return_value=123)
 async def test_log_success(time, task_logger, in_memory_gateway, message, expected):
-    await task_logger.start()
+    await task_logger.start(message)
     await task_logger.stop(message)
 
     assert in_memory_gateway.data[1] == expected
@@ -62,7 +62,7 @@ async def test_log_success(time, task_logger, in_memory_gateway, message, expect
 
 @mock.patch("time.time", new=mock.Mock(return_value=123))
 async def test_log_fail(task_logger, in_memory_gateway, message, expected):
-    await task_logger.start()
+    await task_logger.start(message)
     await task_logger.stop(message, exception=ValueError("test"))
 
     assert in_memory_gateway.data[1] == {
@@ -74,7 +74,7 @@ async def test_log_fail(task_logger, in_memory_gateway, message, expected):
 
 @mock.patch("time.time", return_value=123)
 async def test_log_retry(time, task_logger, in_memory_gateway, message, expected):
-    await task_logger.start()
+    await task_logger.start(message)
     await task_logger.stop(message, exception=Retry("test"))
 
     assert in_memory_gateway.data[1] == {

--- a/tests/test_dramatiq_task_logger.py
+++ b/tests/test_dramatiq_task_logger.py
@@ -81,8 +81,8 @@ async def test_log_fail(task_logger, in_memory_gateway, message, expected):
     await task_logger.start(message)
     await task_logger.stop(message, exception=ValueError("test"))
 
-    assert in_memory_gateway.data[1] == {
-        **expected,
+    assert in_memory_gateway.data[2] == {
+        **expected[1],
         "state": "FAILURE",
         "result": None,
     }
@@ -93,7 +93,7 @@ async def test_log_retry(time, task_logger, in_memory_gateway, message, expected
     await task_logger.start(message)
     await task_logger.stop(message, exception=Retry("test"))
 
-    assert in_memory_gateway.data[1] == {
-        **expected,
+    assert in_memory_gateway.data[2] == {
+        **expected[1],
         "state": "RETRY",
     }

--- a/tests/test_dramatiq_task_logger.py
+++ b/tests/test_dramatiq_task_logger.py
@@ -37,7 +37,19 @@ def message():
 
 @pytest.fixture
 def expected():
-    return {
+    return [{
+        "id": 1,
+        "tag_suffix": "task_log",
+        "task_id": "abc123",
+        "name": "my_task",
+        "state": "STARTING",
+        "duration": 0,
+        "retries": 0,
+        "origin": f"host-{os.getpid()}",
+        "argsrepr": b"[1,2]",
+        "kwargsrepr": b'{"foo":"bar"}',
+        "result": None,
+    },{
         "id": 1,
         "tag_suffix": "task_log",
         "task_id": "abc123",
@@ -49,7 +61,7 @@ def expected():
         "argsrepr": b"[1,2]",
         "kwargsrepr": b'{"foo":"bar"}',
         "result": None,
-    }
+    }]
 
 
 @mock.patch("time.time", return_value=123)
@@ -57,7 +69,8 @@ async def test_log_success(time, task_logger, in_memory_gateway, message, expect
     await task_logger.start(message)
     await task_logger.stop(message)
 
-    assert in_memory_gateway.data[1] == expected
+    assert in_memory_gateway.data[1] == expected[0]
+    assert in_memory_gateway.data[2] == expected[1]
 
 
 @mock.patch("time.time", new=mock.Mock(return_value=123))


### PR DESCRIPTION
At the moment, we only log tasks that have finished and have no clue what tasks are currently being executed. This pull request also logs the start of tasks. TODO: how to query Kibana for tasks that have started but not yet finished?