### PR TITLE
Compile outside of the connection acquisition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
   and prevents the use of greenlets, but it also adds overhead because query
   compilation isn't cached.
 
+- Added a 'has_related' subclass argument to SQLGateway, which should be used whenever
+  a gateway contains nested (related) gateways.
+
 - Added SyncSQLProvider and a (partial) implementation SQLAlchemySyncSQLDatabase.
 
 - Don't do any access logging if the access_logger_gateway is not provided

--- a/clean_python/sql/asyncpg_sql_database.py
+++ b/clean_python/sql/asyncpg_sql_database.py
@@ -82,8 +82,10 @@ class AsyncpgSQLDatabase(SQLDatabase):
     async def execute(
         self, query: Executable, bind_params: Optional[Dict[str, Any]] = None
     ) -> List[Json]:
-        async with self.transaction() as transaction:
-            return await transaction.execute(query, bind_params)
+        # compile before acquiring the connection
+        args = compile(query, bind_params)
+        pool = await self.get_pool()
+        return list(map(dict, await pool.fetch(*args)))
 
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[SQLProvider]:  # type: ignore

--- a/tests/sql/test_sql_gateway.py
+++ b/tests/sql/test_sql_gateway.py
@@ -235,28 +235,28 @@ async def test_update_does_not_exist(sql_gateway):
     assert len(sql_gateway.provider.queries) == 1
 
 
-@mock.patch.object(SQLGateway, "get")
-async def test_update_if_unmodified_since_does_not_exist(get_m, sql_gateway):
-    get_m.return_value = None
+@mock.patch.object(SQLGateway, "exists")
+async def test_update_if_unmodified_since_does_not_exist(exists_m, sql_gateway):
+    exists_m.return_value = False
     sql_gateway.provider.result.return_value = []
     with pytest.raises(DoesNotExist):
         await sql_gateway.update(
             {"id": 2}, if_unmodified_since=datetime(2010, 1, 1, tzinfo=timezone.utc)
         )
     assert len(sql_gateway.provider.queries) == 1
-    get_m.assert_awaited_once_with(2)
+    exists_m.assert_awaited_once_with([Filter(field="id", values=[2])])
 
 
-@mock.patch.object(SQLGateway, "get")
-async def test_update_if_unmodified_since_conflict(get_m, sql_gateway):
-    get_m.return_value = {"id": 2, "value": "foo"}
+@mock.patch.object(SQLGateway, "exists")
+async def test_update_if_unmodified_since_conflict(exists_m, sql_gateway):
+    exists_m.return_value = True
     sql_gateway.provider.result.return_value = []
     with pytest.raises(Conflict):
         await sql_gateway.update(
             {"id": 2}, if_unmodified_since=datetime(2010, 1, 1, tzinfo=timezone.utc)
         )
     assert len(sql_gateway.provider.queries) == 1
-    get_m.assert_awaited_once_with(2)
+    exists_m.assert_awaited_once_with([Filter(field="id", values=[2])])
 
 
 async def test_remove(sql_gateway):


### PR DESCRIPTION
As we are stuck with asyncio in raster-service, and query compilation has significant impact on performance, I optimized the asyncpg backend a bit

- don't use a transaction unless necessary
- this allows to pull the query compilation (CPU-intensive) before acquiring the connection, so that the connections can be used more efficiently

In the "get" benchmark I observe an increase in maximum throughput.

main: 764 requests/second ; 15 ms p50 response
this branch: 1036 requests/second ; 17 ms p50 response

![image](https://github.com/nens/clean-python/assets/8937919/182ad170-d383-43a2-bd80-7b6620462bec)
order: first I did this branch, then main