### PR TITLE
Provide a means to avoid transaction in .update, using if_unmodified_since

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@
 
 - Added ProfyleMiddleware.
 
+- Reverted to the old 'optimistic' concurrency control in Repository.update. This
+  can be switched to 'pessimistic' by using a keyword argument.
+
 
 0.10.0 (2024-01-18)
 -------------------

--- a/clean_python/base/domain/gateway.py
+++ b/clean_python/base/domain/gateway.py
@@ -40,11 +40,8 @@ class Gateway(ABC):
         raise NotImplementedError()
 
     async def update_transactional(self, id: Id, func: Callable[[Json], Json]) -> Json:
-        existing = await self.get(id)
-        if existing is None:
-            raise DoesNotExist("record", id)
-        return await self.update(
-            func(existing), if_unmodified_since=existing["updated_at"]
+        raise NotImplementedError(
+            f"{self.__class__} does not implement pessimistic concurrency control"
         )
 
     async def upsert(self, item: Json) -> Json:

--- a/clean_python/base/infrastructure/in_memory_gateway.py
+++ b/clean_python/base/infrastructure/in_memory_gateway.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 from datetime import datetime
+from typing import Callable
 from typing import List
 from typing import Optional
 
@@ -81,6 +82,14 @@ class InMemoryGateway(Gateway):
             return False
         del self.data[id]
         return True
+
+    async def update_transactional(self, id: Id, func: Callable[[Json], Json]) -> Json:
+        existing = await self.get(id)
+        if existing is None:
+            raise DoesNotExist("record", id)
+        return await self.update(
+            func(existing), if_unmodified_since=existing["updated_at"]
+        )
 
 
 # This is a copy-paste of InMemoryGateway:


### PR DESCRIPTION
Together with #51 this should avoid transactions, leading to better performance overall. I also expect that this removes 'idle in transaction' cases and long waiting times for locks, when the event loop is blocked or overfull.

This is in essence the old implementation, but I think with the automatic retries in #38 we should not expect Conflict errors.