### PR TITLE
Fix swagger login issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,6 @@
 
 - Fixed datatype of ctx.path (it was starlette.URL, now it is pydantic_core.Url).
 
-- Replaced FastAPI's favicon.ico with `/favicon.ico`.
-
 - Deprecate `dramatiq` submodule.
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,13 +3,16 @@
 ## 0.16.1 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Reverted "FastAPI's favicon.ico with `/favicon.ico`" because of
+  login issues in Swagger.
 
 
 ## 0.16.0 (2024-07-02)
 ----------------------
 
 - Fixed datatype of ctx.path (it was starlette.URL, now it is pydantic_core.Url).
+
+- Replaced FastAPI's favicon.ico with `/favicon.ico`.
 
 - Deprecate `dramatiq` submodule.
 

--- a/clean_python/fastapi/schema.py
+++ b/clean_python/fastapi/schema.py
@@ -3,54 +3,14 @@ from io import StringIO
 
 import yaml
 from fastapi import FastAPI
-from fastapi import Request
 from fastapi import Response
-from fastapi.openapi.docs import get_redoc_html
-from fastapi.openapi.docs import get_swagger_ui_html
-from fastapi.responses import HTMLResponse
-
-OPENAPI_URL = "/openapi.json"
-FAVICON_URL = "/favicon.ico"
 
 
 def add_cached_openapi_yaml(app: FastAPI) -> None:
-    @app.get(OPENAPI_URL.replace(".json", ".yaml"), include_in_schema=False)
+    @app.get("/openapi.yaml", include_in_schema=False)
     @lru_cache
     def openapi_yaml() -> Response:
         openapi_json = app.openapi()
         yaml_s = StringIO()
         yaml.dump(openapi_json, yaml_s)
         return Response(yaml_s.getvalue(), media_type="text/yaml")
-
-
-def get_openapi_url(request: Request) -> str:
-    root_path = request.scope.get("root_path", "").rstrip("/")
-    return root_path + OPENAPI_URL
-
-
-def add_swagger_ui(app: FastAPI, title: str, client_id: str | None) -> None:
-    # Code below is copied from fastapi.applications to modify the favicon
-    @app.get("/docs", include_in_schema=False)
-    async def swagger_ui_html(request: Request) -> HTMLResponse:
-        return get_swagger_ui_html(
-            openapi_url=get_openapi_url(request),
-            title=f"{title} - Swagger UI",
-            swagger_favicon_url=FAVICON_URL,
-            init_oauth={
-                "clientId": client_id,
-                "usePkceWithAuthorizationCodeGrant": True,
-            }
-            if client_id
-            else None,
-        )
-
-
-def add_redoc(app: FastAPI, title: str) -> None:
-    # Code below is copied from fastapi.applications to modify the favicon
-    @app.get("/redoc", include_in_schema=False)
-    async def redoc_html(request: Request) -> HTMLResponse:
-        return get_redoc_html(
-            openapi_url=get_openapi_url(request),
-            title=f"{title} - ReDoc",
-            redoc_favicon_url=FAVICON_URL,
-        )

--- a/tests/fastapi/test_service_schema.py
+++ b/tests/fastapi/test_service_schema.py
@@ -1,4 +1,3 @@
-from html.parser import HTMLParser
 from http import HTTPStatus
 
 import pytest
@@ -151,26 +150,3 @@ def test_schema_yaml(client: TestClient, expected_schema: Json):
     actual = yaml.safe_load(response.content.decode("utf-8"))
 
     assert actual == expected_schema
-
-
-@pytest.mark.parametrize("path", ["/v1/docs", "/v1/redoc"])
-def test_favicon(client: TestClient, path: str):
-    response = client.get(path)
-    assert response.status_code == HTTPStatus.OK
-
-    # parse favicon from html
-    found = set()
-
-    class FaviconParser(HTMLParser):
-        def handle_starttag(self, tag, attrs):
-            if tag == "link":
-                attr_dict = dict(attrs)
-                if (
-                    attr_dict.get("rel") in {"icon", "shortcut icon"}
-                    and "href" in attr_dict
-                ):
-                    found.add(attr_dict["href"])
-
-    FaviconParser().feed(response.text)
-
-    assert found == {"/favicon.ico"}


### PR DESCRIPTION
I ported the functionality of generating the swagger page from FastAPI, but not completely. Because of that the OAuth2 login was broken. If I have to port that too, it will become a big module (there is actually another endpoint). I think that would be a feeble thing that may break in the future. 

This is not worth it. Let's keep the fastapi favicon.