### PR TITLE
Support multipart file uploads to S3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## 0.19.1 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Added support for multipart uploads to S3.
 
 
 ## 0.19.0 (2025-02-06)

--- a/clean_python/s3/__init__.py
+++ b/clean_python/s3/__init__.py
@@ -4,3 +4,4 @@ from .s3_gateway import *  # NOQA
 from .s3_provider import *  # NOQA
 from .sync_s3_gateway import *  # NOQA
 from .sync_s3_provider import *  # NOQA
+from .types import *  # NOQA

--- a/clean_python/s3/s3_gateway.py
+++ b/clean_python/s3/s3_gateway.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 import inject
 from botocore.exceptions import ClientError
-from types_aiobotocore_s3.type_defs import CompletedPartTypeDef
 from pydantic import AnyHttpUrl
+from types_aiobotocore_s3.type_defs import CompletedPartTypeDef
 
 from clean_python import ctx
 from clean_python import DoesNotExist

--- a/clean_python/s3/s3_gateway.py
+++ b/clean_python/s3/s3_gateway.py
@@ -140,18 +140,34 @@ class S3Gateway(Gateway):
         self,
         id: Id,
         client_method: str,
+        filename: str | None = None,
+        upload_id: str | None = None,
+        part_number: int | None = None,
     ) -> AnyHttpUrl:
+        params = {"Bucket": self.provider.bucket, "Key": self._id_to_key(id)}
+        if filename:
+            params["ResponseContentDisposition"] = f"attachment; filename={filename}"
+        elif client_method == "upload_part":
+            params["UploadId"] = upload_id
+            params["PartNumber"] = part_number
         return await self.provider.client.generate_presigned_url(
-            client_method,
-            Params={"Bucket": self.provider.bucket, "Key": self._id_to_key(id)},
-            ExpiresIn=DEFAULT_EXPIRY,
+            client_method, Params=params, ExpiresIn=DEFAULT_EXPIRY
         )
 
-    async def create_download_url(self, id: Id) -> AnyHttpUrl:
-        return await self._create_presigned_url(id, "get_object")
+    async def create_download_url(
+        self, id: Id, filename: str | None = None
+    ) -> AnyHttpUrl:
+        return await self._create_presigned_url(id, "get_object", filename)
 
     async def create_upload_url(self, id: Id) -> AnyHttpUrl:
         return await self._create_presigned_url(id, "put_object")
+
+    async def create_multipart_upload_url(
+        self, id: Id, upload_id: str, part_number: int
+    ) -> AnyHttpUrl:
+        return await self._create_presigned_url(
+            id, "upload_part", upload_id=upload_id, part_number=part_number
+        )
 
     async def download_file(self, id: Id, file_path: Path) -> None:
         if file_path.exists():

--- a/clean_python/s3/s3_gateway.py
+++ b/clean_python/s3/s3_gateway.py
@@ -161,7 +161,7 @@ class S3Gateway(Gateway):
         return await self._create_presigned_url(id, "get_object", filename)
 
     async def create_upload_url(
-        self, id: Id, upload_id: str, part_number: int
+        self, id: Id, upload_id: str | None = None, part_number: int | None = None
     ) -> AnyHttpUrl:
         if upload_id is None and part_number is None:
             return await self._create_presigned_url(id, "put_object")

--- a/clean_python/s3/s3_gateway.py
+++ b/clean_python/s3/s3_gateway.py
@@ -160,15 +160,15 @@ class S3Gateway(Gateway):
     ) -> AnyHttpUrl:
         return await self._create_presigned_url(id, "get_object", filename)
 
-    async def create_upload_url(
-        self, id: Id, upload_id: str | None = None, part_number: int | None = None
+    async def create_upload_url(self, id: Id) -> AnyHttpUrl:
+        return await self._create_presigned_url(id, "put_object")
+
+    async def create_multipart_upload_url(
+        self, id: Id, upload_id: str, part_number: int
     ) -> AnyHttpUrl:
-        if upload_id is None and part_number is None:
-            return await self._create_presigned_url(id, "put_object")
-        else:
-            return await self._create_presigned_url(
-                id, "upload_part", upload_id=upload_id, part_number=part_number
-            )
+        return await self._create_presigned_url(
+            id, "upload_part", upload_id=upload_id, part_number=part_number
+        )
 
     async def begin_multipart_upload(self, id: Id) -> str:
         """Initiate a multipart upload."""

--- a/clean_python/s3/s3_gateway.py
+++ b/clean_python/s3/s3_gateway.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import inject
 from botocore.exceptions import ClientError
-from mypy_boto3_s3.type_defs import CompletedPartTypeDef
+from types_aiobotocore_s3.type_defs import CompletedPartTypeDef
 from pydantic import AnyHttpUrl
 
 from clean_python import ctx

--- a/clean_python/s3/sync_s3_gateway.py
+++ b/clean_python/s3/sync_s3_gateway.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import inject
 from botocore.exceptions import ClientError
-from mypy_boto3_s3.type_defs import CompletedPartTypeDef
 from pydantic import AnyHttpUrl
 
 from clean_python import ctx
@@ -17,6 +16,7 @@ from clean_python import PageOptions
 from clean_python import SyncGateway
 
 from .sync_s3_provider import SyncS3BucketProvider
+from .types import CompletedPart
 
 DEFAULT_EXPIRY = 3600  # in seconds
 DEFAULT_TIMEOUT = 1.0
@@ -147,7 +147,9 @@ class SyncS3Gateway(SyncGateway):
     ) -> AnyHttpUrl:
         params = {"Bucket": self.provider.bucket, "Key": self._id_to_key(id)}
         if filename:
-            params["ResponseContentDisposition"] = f"attachment; filename={filename}"
+            params[
+                "ResponseContentDisposition"
+            ] = f"attachment; filename={filename}"  # noqa
         elif client_method == "upload_part":
             params["UploadId"] = upload_id
             params["PartNumber"] = part_number
@@ -176,14 +178,18 @@ class SyncS3Gateway(SyncGateway):
         return result["UploadId"]
 
     def commit_multipart_upload(
-        self, id: Id, upload_id: str, parts: list[CompletedPartTypeDef]
+        self, id: Id, upload_id: str, parts: list[CompletedPart]
     ) -> None:
         """Finalize a multipart upload by assembling its parts."""
         self.provider.client.complete_multipart_upload(
             Bucket=self.provider.bucket,
             Key=self._id_to_key(id),
             UploadId=upload_id,
-            MultipartUpload={"Parts": parts},
+            MultipartUpload={
+                "Parts": [
+                    {"ETag": x["etag"], "PartNumber": x["part_number"]} for x in parts
+                ]
+            },
         )
 
     def rollback_multipart_upload(self, id: Id, upload_id: str) -> None:

--- a/clean_python/s3/sync_s3_gateway.py
+++ b/clean_python/s3/sync_s3_gateway.py
@@ -183,7 +183,7 @@ class SyncS3Gateway(SyncGateway):
             Bucket=self.provider.bucket,
             Key=self._id_to_key(id),
             UploadId=upload_id,
-            MultipartUpload={"Parts": parts}
+            MultipartUpload={"Parts": parts},
         )
 
     def rollback_multipart_upload(self, id: Id, upload_id: str) -> None:

--- a/clean_python/s3/sync_s3_gateway.py
+++ b/clean_python/s3/sync_s3_gateway.py
@@ -158,15 +158,15 @@ class SyncS3Gateway(SyncGateway):
     def create_download_url(self, id: Id, filename: str | None = None) -> AnyHttpUrl:
         return self._create_presigned_url(id, "get_object", filename)
 
-    def create_upload_url(
-        self, id: Id, upload_id: str | None = None, part_number: int | None = None
+    def create_upload_url(self, id: Id) -> AnyHttpUrl:
+        return self._create_presigned_url(id, "put_object")
+
+    def create_multipart_upload_url(
+        self, id: Id, upload_id: str, part_number: int
     ) -> AnyHttpUrl:
-        if upload_id is None and part_number is None:
-            return self._create_presigned_url(id, "put_object")
-        else:
-            return self._create_presigned_url(
-                id, "upload_part", upload_id=upload_id, part_number=part_number
-            )
+        return self._create_presigned_url(
+            id, "upload_part", upload_id=upload_id, part_number=part_number
+        )
 
     def begin_multipart_upload(self, id: Id) -> str:
         """Initiate a multipart upload."""

--- a/clean_python/s3/sync_s3_gateway.py
+++ b/clean_python/s3/sync_s3_gateway.py
@@ -148,7 +148,6 @@ class SyncS3Gateway(SyncGateway):
         if filename:
             params["ResponseContentDisposition"] = f"attachment; filename={filename}"
         elif client_method == "upload_part":
-            assert upload_id and part_number
             params["UploadId"] = upload_id
             params["PartNumber"] = part_number
         return self.provider.client.generate_presigned_url(

--- a/clean_python/s3/sync_s3_gateway.py
+++ b/clean_python/s3/sync_s3_gateway.py
@@ -160,11 +160,31 @@ class SyncS3Gateway(SyncGateway):
     def create_upload_url(self, id: Id) -> AnyHttpUrl:
         return self._create_presigned_url(id, "put_object")
 
+    def create_multipart_upload(self, id: Id) -> str:
+        """Initiate a multipart upload."""
+        result = self.provider.client.create_multipart_upload(
+            Bucket=self.provider.bucket, Key=self._id_to_key(id)
+        )
+        return result["UploadId"]
+
     def create_multipart_upload_url(
         self, id: Id, upload_id: str, part_number: int
     ) -> AnyHttpUrl:
+        """Return a presigned URL for uploading a part."""
         return self._create_presigned_url(
             id, "upload_part", upload_id=upload_id, part_number=part_number
+        )
+
+    def complete_multipart_upload(self, id: Id, upload_id: str) -> None:
+        """Complete a multipart upload by assembling its parts."""
+        self.provider.client.complete_multipart_upload(
+            Bucket=self.provider.bucket, Key=self._id_to_key(id), UploadId=upload_id
+        )
+
+    def abort_multipart_upload(self, id: Id, upload_id: str) -> None:
+        """Abort a multipart upload and delete its parts."""
+        self.provider.client.abort_multipart_upload(
+            Bucket=self.provider.bucket, Key=self._id_to_key(id), UploadId=upload_id
         )
 
     def download_file(self, id: Id, file_path: Path) -> None:

--- a/clean_python/s3/sync_s3_gateway.py
+++ b/clean_python/s3/sync_s3_gateway.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import inject
 from botocore.exceptions import ClientError
+from mypy_boto3_s3.type_defs import CompletedPartTypeDef
 from pydantic import AnyHttpUrl
 
 from clean_python import ctx
@@ -174,17 +175,19 @@ class SyncS3Gateway(SyncGateway):
         )
         return result["UploadId"]
 
-    def commit_multipart_upload(self, id: Id, upload_id: str, parts) -> None:
+    def commit_multipart_upload(
+        self, id: Id, upload_id: str, parts: list[CompletedPartTypeDef]
+    ) -> None:
         """Finalize a multipart upload by assembling its parts."""
         self.provider.client.complete_multipart_upload(
             Bucket=self.provider.bucket,
             Key=self._id_to_key(id),
             UploadId=upload_id,
-            MultipartUpload={"Parts": parts},
+            MultipartUpload={"Parts": parts}
         )
 
     def rollback_multipart_upload(self, id: Id, upload_id: str) -> None:
-        """Cancel a multipart upload and delete its parts."""
+        """Cancel a multipart upload and delete any parts."""
         self.provider.client.abort_multipart_upload(
             Bucket=self.provider.bucket, Key=self._id_to_key(id), UploadId=upload_id
         )

--- a/clean_python/s3/types.py
+++ b/clean_python/s3/types.py
@@ -1,0 +1,10 @@
+# (c) Nelen & Schuurmans
+
+from typing import TypedDict
+
+__all__ = ["CompletedPart"]
+
+
+class CompletedPart(TypedDict):
+    etag: str
+    part_number: int

--- a/integration_tests/test_sync_s3_gateway.py
+++ b/integration_tests/test_sync_s3_gateway.py
@@ -149,7 +149,7 @@ def test_create_upload_url(s3_gateway: SyncS3Gateway, object_in_s3):
 
 
 def test_create_multipart_upload_url(s3_gateway: SyncS3Gateway, object_in_s3):
-    actual = s3_gateway.create_multipart_upload_url(object_in_s3, "foo", 1)
+    actual = s3_gateway.create_upload_url(object_in_s3, "foo", 1)
 
     assert object_in_s3 in actual
     assert "X-Amz-Expires=3600" in actual

--- a/integration_tests/test_sync_s3_gateway.py
+++ b/integration_tests/test_sync_s3_gateway.py
@@ -148,6 +148,16 @@ def test_create_upload_url(s3_gateway: SyncS3Gateway, object_in_s3):
     assert "X-Amz-SignedHeaders=host" in actual
 
 
+def test_create_multipart_upload_url(s3_gateway: SyncS3Gateway, object_in_s3):
+    actual = s3_gateway.create_multipart_upload_url(object_in_s3, "foo", 1)
+
+    assert object_in_s3 in actual
+    assert "X-Amz-Expires=3600" in actual
+    assert "X-Amz-SignedHeaders=host" in actual
+    assert f"uploadId=foo" in actual
+    assert f"partNumber=1" in actual
+
+
 def test_remove_filtered_all(s3_gateway: SyncS3Gateway, multiple_objects):
     s3_gateway.remove_filtered([])
 

--- a/integration_tests/test_sync_s3_gateway.py
+++ b/integration_tests/test_sync_s3_gateway.py
@@ -154,8 +154,8 @@ def test_create_multipart_upload_url(s3_gateway: SyncS3Gateway, object_in_s3):
     assert object_in_s3 in actual
     assert "X-Amz-Expires=3600" in actual
     assert "X-Amz-SignedHeaders=host" in actual
-    assert f"uploadId=foo" in actual
-    assert f"partNumber=1" in actual
+    assert "uploadId=foo" in actual
+    assert "partNumber=1" in actual
 
 
 def test_remove_filtered_all(s3_gateway: SyncS3Gateway, multiple_objects):

--- a/integration_tests/test_sync_s3_gateway.py
+++ b/integration_tests/test_sync_s3_gateway.py
@@ -149,7 +149,7 @@ def test_create_upload_url(s3_gateway: SyncS3Gateway, object_in_s3):
 
 
 def test_create_multipart_upload_url(s3_gateway: SyncS3Gateway, object_in_s3):
-    actual = s3_gateway.create_upload_url(object_in_s3, "foo", 1)
+    actual = s3_gateway.create_multipart_upload_url(object_in_s3, "foo", 1)
 
     assert object_in_s3 in actual
     assert "X-Amz-Expires=3600" in actual

--- a/tests/s3/test_sync_s3_gateway.py
+++ b/tests/s3/test_sync_s3_gateway.py
@@ -65,7 +65,7 @@ def test_create_upload_url(gateway: SyncS3Gateway, provider: Mock):
 def test_create_multipart_upload_url(gateway: SyncS3Gateway, provider: Mock):
     provider.client.generate_presigned_url.return_value = "https://s3.com/S3Object"
 
-    actual = gateway.create_multipart_upload_url("S3Object", "foo", 1)
+    actual = gateway.create_upload_url("S3Object", "foo", 1)
 
     assert actual == provider.client.generate_presigned_url.return_value
     provider.client.generate_presigned_url.assert_called_once_with(

--- a/tests/s3/test_sync_s3_gateway.py
+++ b/tests/s3/test_sync_s3_gateway.py
@@ -65,7 +65,7 @@ def test_create_upload_url(gateway: SyncS3Gateway, provider: Mock):
 def test_create_multipart_upload_url(gateway: SyncS3Gateway, provider: Mock):
     provider.client.generate_presigned_url.return_value = "https://s3.com/S3Object"
 
-    actual = gateway.create_multipart_upload_url("S3Object", "foobar", 1)
+    actual = gateway.create_multipart_upload_url("S3Object", "foo", 1)
 
     assert actual == provider.client.generate_presigned_url.return_value
     provider.client.generate_presigned_url.assert_called_once_with(
@@ -73,7 +73,7 @@ def test_create_multipart_upload_url(gateway: SyncS3Gateway, provider: Mock):
         Params={
             "Bucket": "S3Bucket",
             "Key": "S3Object",
-            "UploadId": "foobar",
+            "UploadId": "foo",
             "PartNumber": 1,
         },
         ExpiresIn=DEFAULT_EXPIRY,

--- a/tests/s3/test_sync_s3_gateway.py
+++ b/tests/s3/test_sync_s3_gateway.py
@@ -65,7 +65,7 @@ def test_create_upload_url(gateway: SyncS3Gateway, provider: Mock):
 def test_create_multipart_upload_url(gateway: SyncS3Gateway, provider: Mock):
     provider.client.generate_presigned_url.return_value = "https://s3.com/S3Object"
 
-    actual = gateway.create_upload_url("S3Object", "foo", 1)
+    actual = gateway.create_multipart_upload_url("S3Object", "foo", 1)
 
     assert actual == provider.client.generate_presigned_url.return_value
     provider.client.generate_presigned_url.assert_called_once_with(

--- a/tests/s3/test_sync_s3_gateway.py
+++ b/tests/s3/test_sync_s3_gateway.py
@@ -60,3 +60,21 @@ def test_create_upload_url(gateway: SyncS3Gateway, provider: Mock):
         Params={"Bucket": "S3Bucket", "Key": "S3Object"},
         ExpiresIn=DEFAULT_EXPIRY,
     )
+
+
+def test_create_multipart_upload_url(gateway: SyncS3Gateway, provider: Mock):
+    provider.client.generate_presigned_url.return_value = "https://s3.com/S3Object"
+
+    actual = gateway.create_multipart_upload_url("S3Object", "foobar", 1)
+
+    assert actual == provider.client.generate_presigned_url.return_value
+    provider.client.generate_presigned_url.assert_called_once_with(
+        "upload_part",
+        Params={
+            "Bucket": "S3Bucket",
+            "Key": "S3Object",
+            "UploadId": "foobar",
+            "PartNumber": 1,
+        },
+        ExpiresIn=DEFAULT_EXPIRY,
+    )


### PR DESCRIPTION
- Since multipart uploads resemble database transactions, I have borrowed the begin/commit/rollback terminology.
- I noticed that the sync and async versions of `create_download_url` were out of sync. This has been fixed.
- There are no breaking changes in this pull request.